### PR TITLE
Use /usr/bin/env python to invoke python2

### DIFF
--- a/generate_mem_diagram.py
+++ b/generate_mem_diagram.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 from __future__ import division
 # The MIT License (MIT)
 # Copyright (c) 2018 Rebecca ".bx" Shapiro

--- a/generate_mem_diagram.py
+++ b/generate_mem_diagram.py
@@ -1,4 +1,4 @@
-#!/bin/python2
+#!/usr/bin/env python
 from __future__ import division
 # The MIT License (MIT)
 # Copyright (c) 2018 Rebecca ".bx" Shapiro


### PR DESCRIPTION
When in Ubuntu 18.10, I needed to change the interpreter directive to get this working. Should be safe to use everywhere, I think.